### PR TITLE
refactor: add check_mode conditions to prevent actions during dry runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Molecule test scenarios for apache and php roles
 - GitHub Actions CI/CD workflows for linting and testing
 
+## [0.0.2] - 2025-10-28
+### Added
+- Validation for virtual host `listen` ports to ensure they match configured `apache_http_ports` or `apache_https_ports`
+- Default values for virtual host `listen` attribute (`*:80` for HTTP, `*:443` for HTTPS)
+
+### Fixed
+- Virtual host templates now use default listen values when not explicitly defined
+- Fixed variable name typo: `apache_vhosts_from_templates` → `apache_vhosts_from_template`
+- Fixed Apache handler to properly guard against accessing undefined attributes in check mode

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,307 @@
+# Project Overview
+This project, `jlira.web_server`, is an Ansible collection designed to automate the setup, configuration, and management of web servers on Linux systems. Its primary goal is to provide idempotent, reusable, and well-documented roles for provisioning Apache web servers and PHP runtimes. The intended audience is system administrators, DevOps engineers, and developers who need a standardized and automated way to deploy and maintain web infrastructure.
+
+## Technology Stack
+- **Ansible**: The core automation engine used for configuration management and application deployment.
+- **YAML**: The language used for writing Ansible playbooks and role definitions.
+- **Jinja2**: The templating engine used for creating dynamic configuration files.
+- **Molecule**: The testing framework used for developing and verifying the functionality of Ansible roles across different environments.
+- **Docker**: Used by Molecule to create containerized environments for testing roles.
+- **GitHub Actions**: The CI/CD platform used for automating linting, testing, and validation of the collection.
+
+## Key Features
+The collection provides the following Ansible roles and functionalities:
+- **`jlira.web_server.apache`**:
+    - Installs the Apache web server (`apache2`).
+    - Manages the Apache service (start, stop, restart, enable).
+    - Deploys custom web pages.
+    - Configures virtual hosts.
+- **`jlira.web_server.php`**:
+    - Installs specific versions of PHP.
+    - Configures PHP for both CLI and FPM (FastCGI Process Manager) usage.
+    - Manages PHP-FPM service.
+    - Adjusts `php.ini` settings for performance and security.
+
+## Folder Structure
+A high-level overview of the project's directory layout:
+```
+/
+├── roles/ - Contains the core Ansible roles.
+│   ├── apache/ - Role for managing the Apache web server.
+│   └── php/ - Role for managing PHP.
+├── extensions/ - Houses extensions and testing configurations.
+│   └── molecule/ - Contains Molecule testing scenarios for the roles.
+│       ├── apache/ - Tests for the `apache` role.
+│       └── php/ - Tests for the `php` role.
+├── .github/ - CI/CD workflows.
+│   └── workflows/ - GitHub Actions workflows for automated testing.
+├── galaxy.yml - Ansible collection metadata.
+├── README.md - The main README file for the project.
+└── ... (other configuration and documentation files)
+```
+
+## Architecture and Design Principles
+The project is structured as an Ansible collection, which is the standard way to distribute and reuse Ansible content. It follows the official Ansible role directory structure.
+
+- **Idempotency**: All roles and tasks are designed to be idempotent. Running them multiple times will result in the same system state, preventing unintended changes.
+- **Modularity**: Each role has a single, clear purpose (e.g., managing Apache, managing PHP). This separation of concerns makes the roles easier to maintain, test, and reuse.
+- **Default Variables**: Roles provide sensible default variables in `defaults/main.yml`, which can be easily overridden by the user for customization.
+- **Testing**: Every role is accompanied by a Molecule test suite to ensure its correctness and reliability. Tests cover installation, configuration, and idempotency.
+- **CI/CD**: The repository is configured with GitHub Actions workflows to automatically run `ansible-lint`, `yamllint`, and Molecule tests on every pull request and merge to the main branch.
+
+## Technical Constraints and Guidelines
+- **Linting**: All YAML and Ansible files must pass `yamllint` and `ansible-lint` checks before being committed. Configuration for these linters is provided in `.yamllint.yml` and `.ansible-lint`.
+- **Variable Naming**: Role variables should be prefixed with the role name (e.g., `apache_port`, `php_version`) to avoid naming conflicts.
+- **Commits**: Commit messages should follow a conventional format, clearly describing the change.
+- **Documentation**: New features or changes to existing roles must be documented in the role's `README.md` file.
+- **Testing**: Any new functionality must be accompanied by corresponding Molecule tests to validate its behavior.
+
+## Best Practices and Tips
+-   **Generic Best Practices:**
+    - Prefer YAML instead of JSON: Although Ansible allows JSON syntax, using YAML is preferred and improves the readability of files and projects.
+    - Use consistent whitespaces: To separate things nicely and improve readability, consider leaving a blank line between blocks, tasks, or other components.
+    - Use a consistent tagging strategy: Tagging is a powerful concept in Ansible since it allows us to group and manage tasks more granularly.  Tags provide us with the option to add fine-grained controls to the execution of tasks.
+    - Use a consistent naming strategy: Before starting to set up your Ansible projects, consider applying a consistent naming convention for your tasks (always name them), plays, variables, roles, and modules.
+    - Define a style guide: Following a style guide might be helpful to be consistent with the above suggestions. Example: openshift-ansible Style Guide
+    - Keep it simple: Ansible provides many options and advanced features, but that doesn’t mean we have to use all of them. Find the Ansible parts and mechanics that fit your use case and keep your Ansible projects as simple as possible. For example, begin with a simple playbook and static inventory and add more complex structures or refactor later according to your needs.
+    - Store your projects in a Version Control System (VCS): Keep your Ansible files in a code repository and commit any new changes regularly.
+    - Don’t store sensitive values in plain text: For secrets and sensitive values, use Ansible Vault to encrypt variables and files and protect any sensitive information.
+    - Test your ansible projects: Use linting tools like Ansible Lint and add testing steps in your CI/CD pipelines for your Ansible repositories. For testing Ansible roles, have a look at Molecule. To test inputs or verify custom expressions, you can use the assert module.
+-   **Inventory Best Practices:**
+    - Use inventory groups: Group hosts based on common attributes they might share (geography, purpose, roles, environment).
+    - Separate Inventory per Environment: Define a separate inventory file per environment (production, staging, testing, etc.) to isolate them from each other and avoid mistakes by targeting the wrong environments.
+    - Dynamic Inventory: When working with cloud providers and ephemeral or fast-changing environments, maintaining static inventories might quickly become complex. Instead, set up a mechanism to synchronize the inventory dynamically with your cloud providers.
+    - Leverage Dynamic Grouping at runtime: We can create dynamic groups using the `group_by` module based on a specific attribute. For example, group hosts dynamically based on their operating system and run different tasks on each without defining such groups in the inventory.
+    ```
+    - name: Gather facts from all hosts
+      hosts: all
+      tasks:
+        - name: Classify hosts depending on their OS distribution
+          group_by:
+            key: OS_{{ ansible_facts['distribution'] }}
+
+    # Only for the Ubuntu hosts
+    - hosts: OS_Ubuntu
+      tasks:
+        - # tasks that only happen on Ubuntu go here
+
+    # Only for the CentOS hosts
+    - hosts: OS_CentOS
+      tasks:
+        - # tasks that only happen on CentOS go here
+    ```
+-   **Plays & Playbooks Best Practices**
+    - Keep it as simple as possible: Try to keep your tasks simple. There are many options and nested structures in Ansible, and by combining lots of features, you can end up with fairly complex setups. Spending some time simplifying your Ansible artifacts pays off in the long term.
+    - Always give descriptive names to your tasks, plays, and playbooks: Choose names that help you and others quickly understand the artifact’s functionality and purpose.
+    - Strive for readability: Use 2-space indentation and add blank lines between tasks to increase readability.
+    - Use comments when necessary: There will be times when the task definition won’t be enough to explain the whole situation, so feel free to use comments for more complex parts of playbooks.
+    - Always mention the state of tasks explicitly: Many modules have a default state that allows us to skip the state parameter. It’s always better to be explicit in these cases to avoid confusion.
+    - Place every task argument in its own separate line:  This point is in line with the general approach of striving for readability in our Ansible files. Check the examples below.
+    This works but isn’t readable enough:
+    ```
+    - name: Add the user {{ username }}
+      ansible.builtin.user: name={{ username }} state=present uid=999999 generate_ssh_key=yes
+      become: yes
+    ```
+    Use this syntax instead, which improves a lot the readability and understandability of the tasks and their arguments:
+    ```
+    - name: Add the user {{ username }}
+      ansible.builtin.user:
+        name: "{{ username }}"
+        state: present
+        uid: 999999
+        generate_ssh_key: yes
+      become: yes
+    ```
+    - Use top-level playbooks to orchestrate other lower-level playbooks: You can logically group tasks, plays, and roles into low-level playbooks and use other top-level playbooks to import them and set up an orchestration layer according to your needs.
+    - Use block syntax to group tasks: Tasks that relate to each other and share common attributes or tags can be grouped using the block option. Another advantage of this option is easier rollbacks for tasks under the same block.
+    ```
+    - name: Install, configure, and start an Nginx web server
+      block:
+        - name: Update and upgrade apt
+          ansible.builtin.apt:
+            update_cache: yes
+            cache_valid_time: 3600
+            upgrade: yes
+
+        - name: "Install Nginx"
+          ansible.builtin.apt:
+            name: nginx
+            state: present
+
+        - name: Copy the Nginx configuration file to the host
+          template:
+            src: templates/nginx.conf.j2
+            dest: /etc/nginx/sites-available/default
+
+        - name: Create link to the new config to enable it
+          file:
+            dest: /etc/nginx/sites-enabled/default
+            src: /etc/nginx/sites-available/default
+            state: link
+
+        - name: Create Nginx directory
+          ansible.builtin.file:
+            path: /home/ubuntu/nginx
+            state: directory
+
+        - name: Copy index.html to the Nginx directory
+          copy:
+            src: files/index.html
+            dest: /home/ubuntu/nginx/index.html
+          notify: Restart the Nginx service
+      when: ansible_facts['distribution'] == 'Ubuntu'
+      tags: nginx
+      become: true
+      become_user: root
+    ```
+    - Use handlers for tasks that should be triggered: Handlers allow a task to be executed after something has changed. This handler will be triggered when there are changes to index.html from the above example.
+    ```
+    handlers:
+      - name: Restart the Nginx service
+        service:
+          name: nginx
+          state: restarted
+        become: true
+        become_user: root
+    ```
+-   **Variables Best Practices**
+    -   Use `_` separators for variable names (e.g., `my_var_name`).
+    -   All strings containing special characters should be enclosed in double quotes.
+    - Always provide sane defaults for your variables: Set default values for all groups under group_vars/all. For every role, set default role variables in roles/<role_name>/defaults/main.yml.
+    - Use groups_vars and host_vars directories: To keep your inventory file clean, prefer setting group and hosts variables in the groups_vars and host_vars directories.
+    - Add the role’s name as a prefix to variables: Try to be explicit when defining variable names for your roles by adding a prefix with the role name.
+    ```
+    nginx_port: 80
+    apache_port: 8080
+    ```
+    - Keep your variable’s setup simple: Many options are available for setting variables in Ansible. Using all of them isn’t probably the way to go unless you have specific needs. Pick the ones more appropriate for your use case and keep it as simple as possible.
+    - Use vault to save sensitive data: vault files ensure sensitive information remains protected while keeping your setup straightforward and easy to manage with tools like grep.
+    Use a group_vars/{group_name} to define all variables in the vars file, including placeholders for sensitive ones, and store actual sensitive data in the vault file, prefixed with vault_. Use Jinja2 syntax in the vars file to reference these encrypted variables
+    ```
+    group_vars/webservers/vars:
+    db_host: "localhost"
+    db_name: "webapp"
+    db_user: "{{ vault_db_user }}"
+    db_password: "{{ vault_db_password }}"
+
+    group_vars/webservers/vault:
+    vault_db_user: "secure_user"
+    vault_db_password: "super_secret_password"
+
+    # Encrypt the Vault File:
+    ansible-vault encrypt group_vars/webservers/vault
+    ```
+    - Documents all variables, for example:
+   ```
+    # List of main Apache settings to be configured in apache.conf.
+    # Each setting is defined as a dictionary with the following keys:
+    # - `name`: The name of the Apache directive to configure (e.g.`LimitRequestLine`,`LimitRequestFieldSize`,).
+    # - `value`: The value to assign to the Apache directive.
+    # - `comment` (optional): A comment to include above the directive in the configuration file. Useful for documenting the purpose of the setting.
+    # The name `ServerName` is reserved for use with the `apache_server_name` setting,
+    # so it will be ignored to prevent conflicts.
+    #
+    # Example:
+    # apache_main_settings:
+    #   - name: LimitRequestLine
+    #     value: 8190
+    #     comment: |
+    #       Maximum size of the request line in bytes.
+    #       Helps prevent buffer overflow attacks.
+    #   - name: LimitRequestFieldSize
+    #     value: 8190
+    #     comment: Maximum size of each HTTP request header field in bytes.
+    # Type: List of Dictionaries
+    apache_main_settings: []
+    ```
+
+-   **Modules Best Practices**
+    - Keep local modules close to playbooks: Use each Ansible project’s ./library directory to store relevant custom modules. Playbooks that have a ./library directory relative to their path can directly reference any modules inside it.
+    - Avoid command and shell modules: It’s considered a best practice to limit the usage of command and shell modules only when there isn’t another option. Instead, prefer specialized modules that provide idempotency and proper error handling. Read more about the Ansible shell module.
+    - Specify module arguments when it makes sense: Default values can be omitted in many module arguments. To be more transparent and explicit, we can opt to specify some of these arguments, like the state in our playbook definitions.
+    - Prefer multi-tasks in a module over loops: The most efficient way of defining a list of similar tasks, like installing packages, is to use multiple tasks in a single module.
+    ```
+    - name: Install Docker dependencies
+      ansible.builtin.apt:
+        name:
+          - curl
+          - ca-certificates
+          - gnupg
+          - lsb-release
+        state: latest
+    ```
+    - Document and test your custom modules: Every custom module should include examples, explicitly document dependencies, and describe return responses. New modules should be tested thoroughly before releasing. You can create testing roles and playbooks to test your custom modules and validate different test cases.
+-   **Roles Best Practices**
+    - Follow the Ansible Galaxy Role Directory structure: Leverage the ansible-galaxy init <role_name> command to generate a default role directory layout according to Ansible Galaxy’s standards.
+    - Keep your roles single-purposed: Each role should have a separate responsibility and distinct functionality to conform with the separation of concerns design principle. Separate your roles based on different functionalities or technical domains.
+    - Try to limit role dependencies: By avoiding many dependencies in your roles, you can keep them loosely coupled, develop them independently, and use them without managing complex dependencies between them.
+    - Prefer import_role or include_role: To better control the execution order of roles and tasks, prefer using import_role or include_role over the classic roles option.
+    - Do your due diligence for Ansible Galaxy Roles: When downloading and using content and roles from Galaxy, do your due diligence, validate their content, and pick roles from trustworthy contributors.
+    - Store Galaxy roles used locally: To avoid depending on the upstream of Ansible Galaxy, you can store any roles from Galaxy to your code repositories and manage them as part of your project.
+-   **Execution and Deployments Best Practices and Tricks**
+    - Test changes in staging first: Having a staging or testing environment to test your tasks before production is a great way to validate that your changes have the expected outcome.
+    - Limit task execution to specific hosts: If you want to run a playbook against specific hosts, you can use the --limit flag.
+    - Limit tasks execution to specific tasks based on tags: In case you need to run only specific tasks from a playbook based on tags, you can define which tags to be executed with the --tags flag.
+    - Validate which tasks will run before executing: You can use the --list-tasks flag to confirm which tasks would be run without actually running them.
+    - Validate against which hosts the playbook will run: You can use the --list-hosts flag to confirm which hosts will be affected by the playbook without running it.
+    - Validate which changes will happen without making them: Leverage the --check flag to predict any changes that may occur. Combine it with --diff flag to show differences in changed files.
+    - Start at a specific task: Use the --start-at-task flag to start executing your playbook at a particular task.
+    - Use Rolling Updates to control the number of target machines: By default, Ansible attempts to run the play against all hosts in parallel. To achieve a rolling update setup, you can leverage the serial keyword. Using this keyword, you can define how many to hosts the changes can be performed in parallel.
+    - Control playbook execution strategy: By default, Ansible finishes the execution of each task on all hosts before moving to the next task. If you wish to select another execution strategy
+
+
+## General Workflow
+
+1.  The user starts a task from `tasks.md`.
+2.  The AI agent analyzes the task and workspace context.
+3.  The AI agent explains the planned actions based on the task flow and context.
+4.  The AI agent shows a side-by-side diff in vscode GUI if it's possible.
+5.  The user approves the plan, and the changes are implemented using the appropriate tools.
+6.  Real-time feedback and validation are provided.
+
+## Ansible Development Workflow
+
+1.  Initialize the repository if needed.
+2.  Create a Collection if needed:
+    -   Edit `galaxy.yml`.
+    -   Add `CHANGELOG.md`.
+    -   Edit `meta/runtime.yml`.
+3.  Create a branch for the role if needed.
+4.  Create a role if needed.
+5.  Develop Content (Playbooks/Tasks/Templates):
+    -   Create the tasks first, then the variables.
+    -   Write tasks in YAML, adhering to style guidelines.
+    -   Ensure tasks are idempotent.
+    -   Use appropriate variables, templates, handlers, files, etc.
+    -   Implement documentation and comments.
+    -   For Jinja2 templates (.j2 files), always use `## {mark} ANSIBLE MANAGED FILE ##` header instead of `# {{ ansible_managed }}` to clearly mark files as managed by Ansible.
+    -   **Check Mode Compatibility**: Ensure all tasks work properly in check mode (`--check`). Tasks that manage services or require installed packages should include `when: not ansible_check_mode` to prevent failures during dry-run validation.
+    -   Update the role's `meta/main.yml` and `README.md`.
+6.  Create Tests (Mandatory):
+    -   Create a scenario for each role (molecule scenario should match the role name).
+    -   Design and implement Molecule tests for the new role or feature.
+    -   Test file organization: The test file name in `extensions/molecule/<role>/tests/` must match the task file name in `roles/<role>/tasks/`. For example:
+        -   Task file: `roles/apache/tasks/configure.yml` → Test file: `extensions/molecule/apache/tests/configure.yml`
+        -   Task file: `roles/apache/tasks/install.yml` → Test file: `extensions/molecule/apache/tests/install.yml`
+    -   Define scenarios, platforms, verifiers, etc.
+7.  Local Validation:
+    -   Molecule should be executed from the extensions directory.
+    -   Run a syntax check.
+    -   Run the linter.
+    -   **Test in Check Mode and Diff Mode (Mandatory)**: Always run playbooks with `--check --diff` flags to validate that the playbook works correctly in dry-run mode and shows accurate change predictions. This ensures:
+        -   Tasks are properly guarded with `when: not ansible_check_mode` where needed (e.g., service management before package installation).
+        -   The playbook provides accurate change previews without failing.
+        -   Example: `ansible-playbook playbooks/webserver/web-server-setup.yml --check --diff`
+8.  Review and Submit:
+    -   Organize and review the changes.
+    -   Present the solution and test results to the user.
+
+Develop one role at time using serial and requirement-driven as Development strategy. Start with the highest priority requirement and complete the following four-step cycle for it. Only upon full completion of this cycle should you proceed to the next requirement:
+
+Plan: Define the specific implementation tasks.
+Code & Test: Write the code and its corresponding tests.
+Verify: Provide local validation steps.
+Next: Move to the next requirement.
+
+

--- a/extensions/molecule/php/tests/install_mssql_extension.yml
+++ b/extensions/molecule/php/tests/install_mssql_extension.yml
@@ -40,7 +40,6 @@
         cmd: '$(which php{{ php_version }}) -r "echo ini_get(''extension_dir'');"'
       register: php_extension_dir_output
       changed_when: false
-      check_mode: false
 
     - name: Check for sqlsrv.so
       ansible.builtin.stat:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: jlira
 name: web_server
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.0.1
+version: 0.0.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/playbooks/web-server-setup.yml
+++ b/playbooks/web-server-setup.yml
@@ -44,7 +44,7 @@
 #     -e "web_server_skip_confirm=true"
 
 - name: Setup Web Server with Apache and PHP
-  hosts: webservers
+  hosts: all
   become: true
 
   pre_tasks:
@@ -95,15 +95,19 @@
       ansible.builtin.command: apache2 -v
       register: apache_version_check
       changed_when: false
+      # when: not ansible_check_mode
 
     - name: Verify PHP installation
       ansible.builtin.command: php --version
       register: php_version_check
       changed_when: false
-      when: php_fpm_enabled | default(true)
+      when:
+        - php_fpm_enabled | default(true)
+        # - not ansible_check_mode
 
     - name: Check Apache service status
       ansible.builtin.service_facts:
+      # when: not ansible_check_mode
 
     - name: Display installation summary
       ansible.builtin.debug:
@@ -124,7 +128,7 @@
           - "PHP:"
           - >-
             {{ php_version_check.stdout_lines[0]
-            if php_version_check is defined and php_version_check.stdout_lines | length > 0
+            if php_version_check is not skipped and php_version_check.stdout_lines | default([]) | length > 0
             else 'PHP not installed (disabled)' }}
           - "  • PHP-FPM Enabled: {{ 'Yes' if php_fpm_enabled | default(true) else 'No' }}"
           - "  • PHP-FPM Integration: {{ 'Yes' if apache_php_fpm_integration | default(true) else 'No' }}"

--- a/requirements.md
+++ b/requirements.md
@@ -1,0 +1,29 @@
+# Requirements for jlira.web_server Ansible Collection
+
+## Functional Requirements
+
+The collection must provide the following capabilities through its roles:
+
+### `apache` Role
+
+*   **Installation:** Ensures that Apache and its required modules are installed on the target system.
+*   **Core Configuration:** Manages the main `apache.conf` file, allowing for global directives like `ServerName`, `ServerTokens`, and `LimitRequestLine`. Supports custom environment variables and configuration directories.
+*   **Port Configuration:** Allows configuration of multiple HTTP and HTTPS ports (default: 80 for HTTP, 443 for HTTPS when SSL is enabled).
+*   **Virtual Host Management:** Provides a flexible way to define and manage virtual hosts, supporting both static configuration files and templates for dynamic VHost creation. It also manages custom configuration files.
+*   **PHP Integration:** Orchestrates the installation and configuration of PHP, ensuring that Apache is correctly set up to work with PHP-FPM.
+*   **Security:** Manages security-related aspects, such as enabling SSL/TLS, setting security headers, configuring basic authentication (`.htpasswd`)
+*   **Maintenance:** Handles the creation of custom log directories and validates configuration changes before reloading the Apache service to prevent downtime.
+*   **Monitoring:** Sets up a server status page with controlled access.
+
+### `php` Role
+
+*   **Installation:** Handles the installation of a specific PHP version and its extensions (using PPA). It can also remove and purge old versions if specified.
+*   **Configuration:**
+    *   Configures `php.ini` files for both CLI and PHP-FPM.
+    *   Sets the default system-wide PHP version for CLI and related tools.
+    *   Configures FPM connection pools (`www.conf`).
+*   **Integration:** Sets up PHP-FPM to work with a web server (like Apache) and can set the default PHP version for the system.
+*   **Extension Management:** Supports the installation of additional extensions, with specific support for the Microsoft SQL Server driver (`mssql`).
+*   **Tooling:** Installs and configures related tools like Composer.
+*   **Maintenance:** Sets up log rotation for PHP logs.
+*   **Monitoring:** Configures a PHP-FPM status page for monitoring.

--- a/roles/apache/handlers/main.yml
+++ b/roles/apache/handlers/main.yml
@@ -12,6 +12,7 @@
   changed_when: false
   failed_when: false
   register: apache_configtest_result
+  when: not ansible_check_mode
 
 - name: Display Apache config test warnings
   listen:
@@ -20,7 +21,9 @@
   ansible.builtin.debug:
     msg: "{{ apache_configtest_result.stderr_lines }}"
   when:
+    - not ansible_check_mode
     - apache_configtest_result is defined
+    - apache_configtest_result.rc is defined
     - apache_configtest_result.rc != 0
 
 - name: Reload Apache service
@@ -28,9 +31,11 @@
   ansible.builtin.service:
     name: apache2
     state: reloaded
+  when: not ansible_check_mode
 
 - name: Restart Apache service
   listen: Restart apache
   ansible.builtin.service:
     name: apache2
     state: restarted
+  when: not ansible_check_mode

--- a/roles/apache/tasks/configure.yml
+++ b/roles/apache/tasks/configure.yml
@@ -1,105 +1,111 @@
 # SPDX-License-Identifier: MIT-0
 ---
-- name: Configure ServerName and main settings in apache2.conf
-  ansible.builtin.blockinfile:
-    path: /etc/apache2/apache2.conf
-    block: "{{ lookup('template', 'apache2.conf.j2') }}"
-    marker: "## {mark} ANSIBLE MANAGED BLOCK - Custom settings ##"
-    append_newline: false
-    prepend_newline: true
-    state: present
-  notify: Reload apache
-  when:
-    - exists /etc/apache2/apache2.conf
+- name: Get packages facts
+  ansible.builtin.package_facts:
+    manager: auto
+  no_log: true
 
-- name: Configure custom environment variables in envvars
-  ansible.builtin.blockinfile:
-    path: /etc/apache2/envvars
-    block: "{{ lookup('template', 'envvars.j2') }}"
-    marker: "## {mark} ANSIBLE MANAGED BLOCK - Custom environment variables ##"
-    append_newline: false
-    prepend_newline: true
-    state: present
-  when: apache_envvars | length > 0
-  notify: Reload apache
+- name: Configure apache
+  when: "'apache2' in ansible_facts.packages"
+  block:
+    - name: Configure ServerName and main settings in apache2.conf
+      ansible.builtin.blockinfile:
+        path: /etc/apache2/apache2.conf
+        block: "{{ lookup('template', 'apache2.conf.j2') }}"
+        marker: "## {mark} ANSIBLE MANAGED BLOCK - Custom settings ##"
+        append_newline: false
+        prepend_newline: true
+        state: present
+      notify: Reload apache
 
-- name: Configure ports in ports.conf
-  ansible.builtin.template:
-    src: ports.conf.j2
-    dest: /etc/apache2/ports.conf
-    owner: root
-    group: root
-    mode: "0644"
-  notify: Reload apache
+    - name: Configure custom environment variables in envvars
+      ansible.builtin.blockinfile:
+        path: /etc/apache2/envvars
+        block: "{{ lookup('template', 'envvars.j2') }}"
+        marker: "## {mark} ANSIBLE MANAGED BLOCK - Custom environment variables ##"
+        append_newline: false
+        prepend_newline: true
+        state: present
+      when: apache_envvars | length > 0
+      notify: Reload apache
 
-- name: Enable SSL module
-  ansible.builtin.command:
-    cmd: a2enmod ssl
-  register: apache_enable_ssl_module_result
-  changed_when: "'Enabling module' in apache_enable_ssl_module_result.stdout"
-  when: apache_ssl_enabled
-  notify: Reload apache
+    - name: Configure ports in ports.conf
+      ansible.builtin.template:
+        src: ports.conf.j2
+        dest: /etc/apache2/ports.conf
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Reload apache
 
-- name: Enable Apache modules
-  ansible.builtin.command:
-    cmd: "a2enmod {{ item }}"
-  register: apache_enable_module_result
-  changed_when: "'Enabling module' in apache_enable_module_result.stdout"
-  loop: "{{ apache_modules_enabled }}"
-  notify: Reload apache
+    - name: Enable SSL module
+      ansible.builtin.command:
+        cmd: a2enmod ssl
+      register: apache_enable_ssl_module_result
+      changed_when: "'Enabling module' in apache_enable_ssl_module_result.stdout"
+      when: apache_ssl_enabled
+      notify: Reload apache
 
-- name: Configure default HTTP virtual host
-  ansible.builtin.template:
-    src: 000-default.conf.j2
-    dest: /etc/apache2/sites-available/000-default.conf
-    owner: root
-    group: root
-    mode: "0644"
-  notify: Reload apache
+    - name: Enable Apache modules
+      ansible.builtin.command:
+        cmd: "a2enmod {{ item }}"
+      register: apache_enable_module_result
+      changed_when: "'Enabling module' in apache_enable_module_result.stdout"
+      loop: "{{ apache_modules_enabled }}"
+      notify: Reload apache
 
-- name: Rename default SSL virtual host configuration
-  ansible.builtin.command:
-    cmd: rm /etc/apache2/sites-available/default-ssl.conf
-  args:
-    removes: /etc/apache2/sites-available/default-ssl.conf
-  notify: Reload apache
+    - name: Configure default HTTP virtual host
+      ansible.builtin.template:
+        src: 000-default.conf.j2
+        dest: /etc/apache2/sites-available/000-default.conf
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Reload apache
 
-- name: Configure default SSL virtual host
-  ansible.builtin.template:
-    src: 000-default-ssl.conf.j2
-    dest: /etc/apache2/sites-available/000-default-ssl.conf
-    owner: root
-    group: root
-    mode: "0644"
-  when: apache_ssl_enabled
-  notify: Reload apache
+    - name: Rename default SSL virtual host configuration
+      ansible.builtin.command:
+        cmd: rm /etc/apache2/sites-available/default-ssl.conf
+      args:
+        removes: /etc/apache2/sites-available/default-ssl.conf
+      notify: Reload apache
 
-- name: Enable default SSL site
-  ansible.builtin.command:
-    cmd: a2ensite 000-default-ssl
-  args:
-    creates: /etc/apache2/sites-enabled/000-default-ssl.conf
-  register: apache_enable_ssl_result
-  changed_when: "'Enabling site' in apache_enable_ssl_result.stdout"
-  when: apache_ssl_enabled
-  notify: Reload apache
+    - name: Configure default SSL virtual host
+      ansible.builtin.template:
+        src: 000-default-ssl.conf.j2
+        dest: /etc/apache2/sites-available/000-default-ssl.conf
+        owner: root
+        group: root
+        mode: "0644"
+      when: apache_ssl_enabled
+      notify: Reload apache
 
-- name: Configure Apache security settings
-  ansible.builtin.lineinfile:
-    path: /etc/apache2/conf-available/security.conf
-    regexp: '^{{ item.name }}'
-    line: '{{ item.name }} {{ item.value }}'
-    state: present
-  loop: "{{ apache_security_settings }}"
-  notify: Reload apache
-  when: not ansible_check_mode
+    - name: Enable default SSL site
+      ansible.builtin.command:
+        cmd: a2ensite 000-default-ssl
+      args:
+        creates: /etc/apache2/sites-enabled/000-default-ssl.conf
+      register: apache_enable_ssl_result
+      changed_when: "'Enabling site' in apache_enable_ssl_result.stdout"
+      when: apache_ssl_enabled
+      notify: Reload apache
 
-- name: Enable security configuration
-  ansible.builtin.command:
-    cmd: a2enconf security
-  args:
-    creates: /etc/apache2/conf-enabled/security.conf
-  notify: Reload apache
+    - name: Configure Apache security settings
+      ansible.builtin.lineinfile:
+        path: /etc/apache2/conf-available/security.conf
+        regexp: '^{{ item.name }}'
+        line: '{{ item.name }} {{ item.value }}'
+        state: present
+      loop: "{{ apache_security_settings }}"
+      notify: Reload apache
+      when: not ansible_check_mode
+
+    - name: Enable security configuration
+      ansible.builtin.command:
+        cmd: a2enconf security
+      args:
+        creates: /etc/apache2/conf-enabled/security.conf
+      notify: Reload apache
 
 # - name: Flush handlers
 #   ansible.builtin.meta: flush_handlers

--- a/roles/apache/tasks/configure.yml
+++ b/roles/apache/tasks/configure.yml
@@ -9,6 +9,8 @@
     prepend_newline: true
     state: present
   notify: Reload apache
+  when:
+    - exists /etc/apache2/apache2.conf
 
 - name: Configure custom environment variables in envvars
   ansible.builtin.blockinfile:
@@ -90,6 +92,7 @@
     state: present
   loop: "{{ apache_security_settings }}"
   notify: Reload apache
+  when: not ansible_check_mode
 
 - name: Enable security configuration
   ansible.builtin.command:

--- a/roles/apache/tasks/install.yml
+++ b/roles/apache/tasks/install.yml
@@ -13,3 +13,4 @@
     name: apache2
     state: started
     enabled: true
+  when: not ansible_check_mode # Don't start service in check_mode if not installed yet

--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -108,7 +108,7 @@
         - apache_virtual_hosts
         - virtual_hosts_from_templates
         - apache_virtual_hosts_from_templates
-  when: (apache_vhost_templates | length > 0) or (apache_vhosts_from_templates | length > 0)
+  when: (apache_vhost_templates | length > 0) or (apache_vhosts_from_template | length > 0)
   tags:
     - virtual_hosts
     - apache_virtual_hosts

--- a/roles/apache/tasks/validate.yml
+++ b/roles/apache/tasks/validate.yml
@@ -490,6 +490,80 @@
     label: "{{ item.name | default('unnamed') }}"
   when: apache_virtual_hosts | length > 0
 
+- name: Validate HTTP virtual host listen is a list
+  ansible.builtin.assert:
+    that:
+      - item.http.listen is iterable
+      - item.http.listen is not string
+      - item.http.listen is not mapping
+      - item.http.listen | length > 0
+    fail_msg: >-
+      Virtual host '{{ item.name }}' has 'http.listen' defined but it's not a valid list.
+      Please define 'http.listen' as a list of address:port or port values (e.g., ['*:80']).
+    success_msg: "Virtual host '{{ item.name }}' HTTP listen is a valid list"
+    quiet: true
+  loop: "{{ apache_virtual_hosts }}"
+  loop_control:
+    label: "{{ item.name | default('unnamed') }}"
+  when:
+    - apache_virtual_hosts | length > 0
+    - item.http is defined
+    - item.http.listen is defined
+
+- name: Validate HTTPS virtual host listen is a list
+  ansible.builtin.assert:
+    that:
+      - item.https.listen is iterable
+      - item.https.listen is not string
+      - item.https.listen is not mapping
+      - item.https.listen | length > 0
+    fail_msg: >-
+      Virtual host '{{ item.name }}' has 'https.listen' defined but it's not a valid list.
+      Please define 'https.listen' as a list of address:port or port values (e.g., ['*:443']).
+    success_msg: "Virtual host '{{ item.name }}' HTTPS listen is a valid list"
+    quiet: true
+  loop: "{{ apache_virtual_hosts }}"
+  loop_control:
+    label: "{{ item.name | default('unnamed') }}"
+  when:
+    - apache_virtual_hosts | length > 0
+    - item.https is defined
+    - item.https.listen is defined
+
+- name: Validate HTTP listen ports match apache_http_ports
+  ansible.builtin.assert:
+    that:
+      - listen_port in apache_http_ports
+    fail_msg: >-
+      Virtual host '{{ item.0.name }}' HTTP listen port '{{ listen_port }}' is not in apache_http_ports {{ apache_http_ports }}.
+      HTTP listen value: '{{ item.1 }}'.
+      Please ensure the port matches one of the configured apache_http_ports or update apache_http_ports to include this port.
+    success_msg: "Virtual host '{{ item.0.name }}' HTTP port {{ listen_port }} is valid"
+    quiet: true
+  loop: "{{ apache_virtual_hosts | selectattr('http', 'defined') | map('combine', {'_listen': item.http.listen | default(['*:80'])}) | list | subelements('_listen') }}"
+  loop_control:
+    label: "{{ item.0.name | default('unnamed') }} - {{ item.1 }}"
+  vars:
+    listen_port: "{{ item.1 | regex_replace('^.*:', '') | int }}"
+  when: apache_virtual_hosts | length > 0
+
+- name: Validate HTTPS listen ports match apache_https_ports
+  ansible.builtin.assert:
+    that:
+      - listen_port in apache_https_ports
+    fail_msg: >-
+      Virtual host '{{ item.0.name }}' HTTPS listen port '{{ listen_port }}' is not in apache_https_ports {{ apache_https_ports }}.
+      HTTPS listen value: '{{ item.1 }}'.
+      Please ensure the port matches one of the configured apache_https_ports or update apache_https_ports to include this port.
+    success_msg: "Virtual host '{{ item.0.name }}' HTTPS port {{ listen_port }} is valid"
+    quiet: true
+  loop: "{{ apache_virtual_hosts | selectattr('https', 'defined') | map('combine', {'_listen': item.https.listen | default(['*:443'])}) | list | subelements('_listen') }}"
+  loop_control:
+    label: "{{ item.0.name | default('unnamed') }} - {{ item.1 }}"
+  vars:
+    listen_port: "{{ item.1 | regex_replace('^.*:', '') | int }}"
+  when: apache_virtual_hosts | length > 0
+
 # =============================================================================
 # 10. Authentication Configuration Validation
 # =============================================================================

--- a/roles/apache/tasks/validate.yml
+++ b/roles/apache/tasks/validate.yml
@@ -535,12 +535,21 @@
     that:
       - listen_port in apache_http_ports
     fail_msg: >-
-      Virtual host '{{ item.0.name }}' HTTP listen port '{{ listen_port }}' is not in apache_http_ports {{ apache_http_ports }}.
+      Virtual host '{{ item.0.name }}' HTTP listen port '{{ listen_port }}'
+      is not in apache_http_ports {{ apache_http_ports }}.
       HTTP listen value: '{{ item.1 }}'.
-      Please ensure the port matches one of the configured apache_http_ports or update apache_http_ports to include this port.
+      Please ensure the port matches one of the configured apache_http_ports
+      or update apache_http_ports to include this port.
     success_msg: "Virtual host '{{ item.0.name }}' HTTP port {{ listen_port }} is valid"
     quiet: true
-  loop: "{{ apache_virtual_hosts | selectattr('http', 'defined') | map('combine', {'_listen': item.http.listen | default(['*:80'])}) | list | subelements('_listen') }}"
+  loop: >-
+    {{
+      apache_virtual_hosts
+      | selectattr('http', 'defined')
+      | map('combine', {'_listen': item.http.listen | default(['*:80'])})
+      | list
+      | subelements('_listen')
+    }}
   loop_control:
     label: "{{ item.0.name | default('unnamed') }} - {{ item.1 }}"
   vars:
@@ -552,12 +561,21 @@
     that:
       - listen_port in apache_https_ports
     fail_msg: >-
-      Virtual host '{{ item.0.name }}' HTTPS listen port '{{ listen_port }}' is not in apache_https_ports {{ apache_https_ports }}.
+      Virtual host '{{ item.0.name }}' HTTPS listen port '{{ listen_port }}'
+      is not in apache_https_ports {{ apache_https_ports }}.
       HTTPS listen value: '{{ item.1 }}'.
-      Please ensure the port matches one of the configured apache_https_ports or update apache_https_ports to include this port.
+      Please ensure the port matches one of the configured apache_https_ports
+      or update apache_https_ports to include this port.
     success_msg: "Virtual host '{{ item.0.name }}' HTTPS port {{ listen_port }} is valid"
     quiet: true
-  loop: "{{ apache_virtual_hosts | selectattr('https', 'defined') | map('combine', {'_listen': item.https.listen | default(['*:443'])}) | list | subelements('_listen') }}"
+  loop: >-
+    {{
+      apache_virtual_hosts
+      | selectattr('https', 'defined')
+      | map('combine', {'_listen': item.https.listen | default(['*:443'])})
+      | list
+      | subelements('_listen')
+    }}
   loop_control:
     label: "{{ item.0.name | default('unnamed') }} - {{ item.1 }}"
   vars:

--- a/roles/apache/templates/vhost-ssl.conf.j2
+++ b/roles/apache/templates/vhost-ssl.conf.j2
@@ -1,7 +1,7 @@
 ## ANSIBLE MANAGED FILE ##
 # HTTPS Virtual Host: {{ item.name }}
 {% if item.https is defined %}
-<VirtualHost {% for listen in item.https.listen %}{{ listen }}{% if not loop.last %} {% endif %}{% endfor %}>
+<VirtualHost {% for listen in item.https.listen | default(['*:443']) %}{{ listen }}{% if not loop.last %} {% endif %}{% endfor %}>
     ServerName {{ item.server_name }}
 {% if item.server_alias is defined and item.server_alias | length > 0 %}
     ServerAlias {{ item.server_alias | join(' ') }}

--- a/roles/apache/templates/vhost.conf.j2
+++ b/roles/apache/templates/vhost.conf.j2
@@ -1,7 +1,7 @@
 ## ANSIBLE MANAGED FILE ##
 # HTTP Virtual Host: {{ item.name }}
 {% if item.http is defined %}
-<VirtualHost {% for listen in item.http.listen %}{{ listen }}{% if not loop.last %} {% endif %}{% endfor %}>
+<VirtualHost {% for listen in item.http.listen | default(['*:80']) %}{{ listen }}{% if not loop.last %} {% endif %}{% endfor %}>
 {% if item.server_name is defined %}
     ServerName {{ item.server_name }}
 {% endif %}

--- a/roles/php/handlers/main.yml
+++ b/roles/php/handlers/main.yml
@@ -4,3 +4,4 @@
   ansible.builtin.service:
     name: "php{{ php_version }}-fpm"
     state: restarted
+  when: not ansible_check_mode

--- a/roles/php/tasks/configure_cli.yml
+++ b/roles/php/tasks/configure_cli.yml
@@ -55,4 +55,5 @@
   loop: "{{ php_cli_settings_list }}"
   loop_control:
     label: "{{ item.line }}"
-  when: "('/etc/php/' ~ php_version ~ '/cli/php.ini' is file) | bool" # Don't fail in check_mode if php.ini not added yet
+  # Don't fail in check_mode if php.ini not added yet
+  when: "('/etc/php/' ~ php_version ~ '/cli/php.ini' is file) | bool"

--- a/roles/php/tasks/configure_cli.yml
+++ b/roles/php/tasks/configure_cli.yml
@@ -11,7 +11,9 @@
     dest: "/etc/php/{{ php_version }}/cli/php.ini.original"
     remote_src: true
     mode: "0644"
-  when: not php_ini_backup_stat.stat.exists
+  when:
+    - not php_ini_backup_stat.stat.exists
+    - not ansible_check_mode
 
 - name: Create PHP CLI error log directory if error_log is defined
   ansible.builtin.file:
@@ -53,3 +55,4 @@
   loop: "{{ php_cli_settings_list }}"
   loop_control:
     label: "{{ item.line }}"
+  when: "('/etc/php/' ~ php_version ~ '/cli/php.ini' is file) | bool" # Don't fail in check_mode if php.ini not added yet

--- a/roles/php/tasks/configure_cli.yml
+++ b/roles/php/tasks/configure_cli.yml
@@ -47,6 +47,11 @@
   ansible.builtin.debug:
     var: php_cli_settings_list
 
+- name: Check if PHP CLI php.ini exists
+  ansible.builtin.stat:
+    path: "/etc/php/{{ php_version }}/cli/php.ini"
+  register: php_cli_ini_stat
+
 - name: Configure PHP CLI settings in php.ini
   ansible.builtin.lineinfile:
     path: "/etc/php/{{ php_version }}/cli/php.ini"
@@ -56,4 +61,4 @@
   loop_control:
     label: "{{ item.line }}"
   # Don't fail in check_mode if php.ini not added yet
-  when: "('/etc/php/' ~ php_version ~ '/cli/php.ini' is file) | bool"
+  when: php_cli_ini_stat.stat.exists

--- a/roles/php/tasks/configure_fpm.yml
+++ b/roles/php/tasks/configure_fpm.yml
@@ -57,7 +57,8 @@
     label: "{{ item.line }}"
   notify: Restart PHP-FPM service
   register: php_fpm_ini_changed
-  when: "('/etc/php/' ~ php_version ~ '/fpm/php.ini' is file) | bool" # Don't fail in check_mode if php.ini not added yet
+  # Don't fail in check_mode if php.ini not added yet
+  when: "('/etc/php/' ~ php_version ~ '/fpm/php.ini' is file) | bool"
 
 - name: Check if backup of FPM pool configuration already exists
   ansible.builtin.stat:

--- a/roles/php/tasks/configure_fpm.yml
+++ b/roles/php/tasks/configure_fpm.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT-0
 ---
-- name: Check if backup of php.ini already exists
+- name: Check if backup of php.ini.original already exists
   ansible.builtin.stat:
     path: "/etc/php/{{ php_version }}/fpm/php.ini.original"
   register: php_ini_backup_stat
@@ -47,6 +47,11 @@
   ansible.builtin.debug:
     var: php_fpm_settings_list
 
+- name: Check if PHP FPM php.ini exists
+  ansible.builtin.stat:
+    path: "/etc/php/{{ php_version }}/fpm/php.ini"
+  register: php_fpm_ini_stat
+
 - name: Configure PHP FPM settings in php.ini
   ansible.builtin.lineinfile:
     path: "/etc/php/{{ php_version }}/fpm/php.ini"
@@ -58,7 +63,7 @@
   notify: Restart PHP-FPM service
   register: php_fpm_ini_changed
   # Don't fail in check_mode if php.ini not added yet
-  when: "('/etc/php/' ~ php_version ~ '/fpm/php.ini' is file) | bool"
+  when: php_fpm_ini_stat.stat.exists
 
 - name: Check if backup of FPM pool configuration already exists
   ansible.builtin.stat:

--- a/roles/php/tasks/configure_fpm.yml
+++ b/roles/php/tasks/configure_fpm.yml
@@ -11,7 +11,9 @@
     dest: "/etc/php/{{ php_version }}/fpm/php.ini.original"
     remote_src: true
     mode: "0644"
-  when: not php_ini_backup_stat.stat.exists
+  when:
+    - not php_ini_backup_stat.stat.exists
+    - not ansible_check_mode
 
 - name: Create PHP FPM error log directory if error_log is defined
   ansible.builtin.file:
@@ -55,6 +57,7 @@
     label: "{{ item.line }}"
   notify: Restart PHP-FPM service
   register: php_fpm_ini_changed
+  when: "('/etc/php/' ~ php_version ~ '/fpm/php.ini' is file) | bool" # Don't fail in check_mode if php.ini not added yet
 
 - name: Check if backup of FPM pool configuration already exists
   ansible.builtin.stat:
@@ -71,6 +74,7 @@
   when:
     - php_pool_settings is defined
     - not php_fpm_pool_backup_stat.stat.exists
+    - not ansible_check_mode
 
 - name: Configure PHP-FPM pool settings from template
   ansible.builtin.template:

--- a/roles/php/tasks/install.yml
+++ b/roles/php/tasks/install.yml
@@ -21,19 +21,24 @@
     state: present
     update_cache: true
     cache_valid_time: 3600
+  when: "('/etc/apt/sources.list.d/ppa_ondrej_php_noble.list' is file)" # Don't fail in check_mode if PPA not added yet
 
 - name: Install PHP-FPM for version {{ php_version }}
   ansible.builtin.apt:
     name: "php{{ php_version }}-fpm"
     state: present
-  when: php_fpm_enabled
+  when:
+    - php_fpm_enabled
+    - "('/etc/apt/sources.list.d/ppa_ondrej_php_noble.list' is file)" # Don't fail in check_mode if PPA not added yet
 
 - name: Ensure PHP-FPM service is started and enabled
   ansible.builtin.service:
     name: "php{{ php_version }}-fpm"
     state: started
     enabled: true
-  when: php_fpm_enabled
+  when:
+    - php_fpm_enabled
+    - not ansible_check_mode # Don't start service in check_mode if not installed yet
 
 - name: Download and install Composer globally
   ansible.builtin.shell: |
@@ -43,4 +48,5 @@
   args:
     creates: /usr/local/bin/composer
     executable: /bin/bash
-  when: php_composer_enabled
+  when:
+    - php_composer_enabled

--- a/roles/php/tasks/install.yml
+++ b/roles/php/tasks/install.yml
@@ -15,13 +15,18 @@
     state: present
     update_cache: true
 
+- name: Check for PPA file existence
+  ansible.builtin.stat:
+    path: /etc/apt/sources.list.d/ppa_ondrej_php_noble.list
+  register: php_ppa_file_stat
+
 - name: Install PHP CLI and packages for version {{ php_version }}
   ansible.builtin.apt:
     name: "{{ ['php' ~ php_version ~ '-cli'] + php_packages }}"
     state: present
     update_cache: true
     cache_valid_time: 3600
-  when: "('/etc/apt/sources.list.d/ppa_ondrej_php_noble.list' is file)" # Don't fail in check_mode if PPA not added yet
+  when: php_ppa_file_stat.stat.exists # Don't fail in check_mode if PPA not added yet
 
 - name: Install PHP-FPM for version {{ php_version }}
   ansible.builtin.apt:
@@ -29,7 +34,7 @@
     state: present
   when:
     - php_fpm_enabled
-    - "('/etc/apt/sources.list.d/ppa_ondrej_php_noble.list' is file)" # Don't fail in check_mode if PPA not added yet
+    - php_ppa_file_stat.stat.exists # Don't fail in check_mode if PPA not added yet
 
 - name: Ensure PHP-FPM service is started and enabled
   ansible.builtin.service:

--- a/roles/php/tasks/set_default_cli_version.yml
+++ b/roles/php/tasks/set_default_cli_version.yml
@@ -13,6 +13,11 @@
   changed_when: false
   failed_when: false
 
+- name: Check if PHP CLI php.ini exists
+  ansible.builtin.stat:
+    path: "/etc/php/{{ php_version }}/cli/php.ini"
+  register: php_cli_ini_stat
+
 - name: Set all PHP CLI tools as default for version {{ php_version }}
   community.general.alternatives:
     name: "{{ item }}"
@@ -24,8 +29,9 @@
     - phar.phar
     - phpize
     - php-config
+  # Don't fail in check_mode if php.ini not added yet
   when: >
     php_cli_set_as_default_version and
     (php_current_version.stdout is not defined or
     php_version not in php_current_version.stdout) and
-    (('/usr/bin/php' ~ php_version is file) | bool)
+    php_cli_ini_stat.stat.exists

--- a/roles/php/tasks/set_default_cli_version.yml
+++ b/roles/php/tasks/set_default_cli_version.yml
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: MIT-0
 ---
-- name: Verify PHP binary exist
+- name: Verify PHP binary exists
   ansible.builtin.stat:
     path: "/usr/bin/php{{ php_version }}"
   register: php_binary_check
   failed_when: not php_binary_check.stat.exists
+  when: not ansible_check_mode
 
 - name: Check current default PHP CLI version
   ansible.builtin.command: php --version
@@ -26,4 +27,5 @@
   when: >
     php_cli_set_as_default_version and
     (php_current_version.stdout is not defined or
-     php_version not in php_current_version.stdout)
+    php_version not in php_current_version.stdout) and
+    (('/usr/bin/php' ~ php_version is file) | bool)

--- a/roles/php/templates/logrotate_cli.conf.j2
+++ b/roles/php/templates/logrotate_cli.conf.j2
@@ -1,3 +1,5 @@
+ ## {mark} ANSIBLE MANAGED FILE ##
+
 {{ php_cli_logrotate_path }} {
     {{ php_cli_logrotate_options | join("
     ") }}

--- a/roles/php/templates/logrotate_fpm.conf.j2
+++ b/roles/php/templates/logrotate_fpm.conf.j2
@@ -1,3 +1,5 @@
+ ## {mark} ANSIBLE MANAGED FILE ##
+
 {{ php_fpm_logrotate_path }} {
     {{ php_fpm_logrotate_options | join("
     ") }}

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,312 @@
+# Apache role
+
+## ✅ 1. Install apache
+
+- ✅ **Installation:**
+  - ✅ Install packages
+- ✅ **Task Organization:**
+  - ✅ Support selective execution via tags
+
+### ✅ 2.1 PHP Setup
+- ✅ **Conditional PHP Installation:**
+  - ✅ Support optional PHP integration (use a php role for install and setup php)
+- ✅ **Task Organization:**
+  - ✅ Support selective execution via tags
+  - ✅ Allow granular control of PHP features
+
+## 3. Configuration Requirements
+
+### ✅ 3.1 Main Apache Configuration
+- ✅ **ServerName Configuration:**
+  - ✅ Configure server hostname
+  - ✅ Support system hostname as default
+  - ✅ Allow custom server names
+
+- ✅ **Apache Main Settings:**
+  - ✅ Support custom Apache directives like LimitRequestLine, LimitRequestFieldSize, etc
+  - ✅ Support documentation via comments
+  - ✅ Support arbitrary user-defined environment variables
+
+- ✅ **SSL Configuration:**
+  - ✅ Enable SSL site by default
+  - ✅ Manage site enablement
+
+- ✅ **Port Configuration:**
+  - ✅ Configure multiple HTTP ports (default: 80)
+  - ✅ Configure multiple HTTPS ports (default: 443, when SSL enabled)
+  - ✅ Manage port configuration
+
+- ✅ **Module Management:**
+  - ✅ Enable additional modules
+  - ✅ Activate modules idempotently
+
+- ✅ **Default Index Page:**
+  - ✅ Create default welcome page
+  - ✅ Set appropriate file ownership and permissions
+
+- ✅ **Default Virtual Host Configuration:**
+  - ✅ Organize default virtual host files
+  - ✅ Integrate PHP-FPM when PHP is enabled
+  - ✅ Configure SSL virtual hosts
+  - ✅ Support custom ports in SSL virtual hosts
+
+- **Security Configuration:**
+  - ✅ Configure server information disclosure settings
+  - ✅ Configure server signature settings
+  - ✅ Configure HTTP method restrictions
+  - ✅ Apply security hardening
+  - ✅ Activate security configurations
+
+### ✅ 3.2 Configuration File Management
+- ✅ Support creation of custom Apache configuration files
+- ✅ Each configuration file includes:
+  - ✅ Descriptive name
+  - ✅ Relative file path
+  - ✅ Configuration body content
+- ✅ Create necessary directory structure
+- ✅ Set appropriate file ownership and permissions
+- ✅ Mark configuration as managed by automation
+- ✅ Trigger validation and reload after changes
+
+## ✅ 4. Virtual Host Requirements
+
+### ✅ 4.1 Virtual Host Management
+- ✅ **Direct Virtual Host Creation:**
+  - ✅ Create virtual host configuration files from specifications
+  - ✅ Support HTTP virtual hosts with:
+    - ✅ Listen addresses and ports
+    - ✅ Server identity (name and aliases)
+    - ✅ Administrative contact
+    - ✅ Document root directory
+    - ✅ Logging configuration
+    - ✅ Custom configuration directives
+  - ✅ Support HTTPS virtual hosts with:
+    - ✅ Secure listen addresses and ports
+    - ✅ SSL certificate configuration
+    - ✅ HTTPS-specific logging
+    - ✅ HTTPS-specific configuration directives
+  - ✅ Create directory structure for virtual host files
+  - ✅ Set appropriate file permissions
+
+- ✅ **Template-Based Virtual Host Creation:**
+  - ✅ Support reusable virtual host templates
+  - ✅ Templates can define variables for substitution
+  - ✅ Create virtual hosts from templates with specific variable values
+  - ✅ Support template inclusion mechanism
+  - ✅ Allow multiple virtual hosts to share common configurations
+
+- ✅ **Virtual Host Features:**
+  - ✅ Support flexible listen directives
+  - ✅ Support variable substitution in configurations
+  - ✅ Automatic validation and reload after changes
+  - ✅ Support for modular configuration via includes
+
+## ✅ 5. Status Page Requirements
+
+### ✅ 5.1 Apache Status Page
+- ✅ Configure server status monitoring endpoint
+- ✅ Support access control via allowed hosts list
+- ✅ Trigger validation and reload after changes
+
+## ✅ 6. Authentication Requirements
+
+### ✅ 6.1 HTTP Authentication
+- ✅ Create and manage password files
+- ✅ Support multiple authentication files
+- ✅ Support multiple users per authentication file
+- ✅ Automatically create password files if they don't exist
+- ✅ Update existing users or add new users idempotently
+
+## 7. Notification and Validation Requirements
+
+### 7.1 Configuration Validation
+- ✅ Trigger configuration validation after changes
+- ✅ Validate configuration syntax before applying
+- ✅ Only apply changes if validation succeeds
+
+### ✅ 7.2 Service Management
+- ✅ Reload service for non-disruptive changes
+- ✅ Restart service when required for disruptive changes
+- ✅ Manage service via system service manager
+
+## ✅ 8. Idempotency Requirements
+
+### ✅ 8.1 Change Detection
+- ✅ Use appropriate automation modules to detect changes
+- ✅ Avoid unnecessary service disruptions
+- ✅ Check current state before making changes
+- ✅ Support dry-run validation mode
+- ✅ Report changes accurately
+
+### ✅ 8.2 File Management
+- ✅ Mark managed configuration sections
+- ✅ Preserve existing configuration outside managed blocks
+- ✅ Create files conditionally when needed
+- ✅ Support idempotent command execution
+
+## 9. Security Requirements
+
+### 9.1 Secure Defaults
+- ✅ ServerTokens set to Prod (minimal information disclosure)
+- ✅ ServerSignature set to Off (hide server signature)
+- ✅ TraceEnable set to Off (prevent HTTP TRACE attacks)
+- ✅ Proper file permissions (0644 for config, 0640 for .htpasswd)
+- ✅ Proper ownership (root:root for config, root:www-data for .htpasswd)
+
+## ✅ 10. Apache PHP-FPM Integration
+
+### ✅ 10.1 PHP-FPM Integration
+- ✅ **Role Integration:**
+  - ✅ Create a new task `php_integration.yml` in the `apache` role.
+  - ✅ Support multiple PHP versions on same system, so configure /etc/apache2/conf-available/php{{ php_version }}-fpm.conf (configure ProxyTimeout, add <If "-f %{REQUEST_FILENAME}"> inside <FilesMatch ".+\.ph(ar|p|tml)$">)
+  - ✅ Add logic to configure wheter set php version as php-fpm default version or not. If default version, create symlink in conf-enabled.
+  - ✅ Update `apache/tasks/main.yml` to include `php_integration.yml` conditionally.
+  - ✅ Enable proxy_fcgi Apache module
+  - ✅ Include PHP role automatically when apache_php_fpm_integration is enabled
+  - ✅ Create comprehensive Molecule tests for PHP-FPM integration
+
+## ✅ 11. Status Page Configuration
+- ✅ **FPM Status Page:**
+  - ✅ Configure proxy timeout settings for FPM connections
+  - ✅ Add file existence checks for PHP file execution
+  - ✅ Configure status page endpoint access
+  - ✅ Create version-specific status and ping endpoints
+  - ✅ Support IP-based access control for status endpoints
+  - ✅ Create real-time status HTML page for PHP-FPM monitoring
+  - ✅ Fix Apache Directory directive to point to directory instead of file
+  - ✅ Deploy fpm-status.html.j2 template for interactive status monitoring
+
+## ✅ 12. Variable Validation
+- ✅ **Apache Role Validation:**
+  - ✅ Create comprehensive validation task file (validate.yml)
+  - ✅ Validate basic configuration (server_name, ssl_enabled)
+  - ✅ Validate PHP-FPM integration settings (version, timeout, set_default)
+  - ✅ Validate PHP-FPM status page configuration (paths, endpoints, allowed_hosts)
+  - ✅ Validate Apache status page configuration (endpoint, allowed_hosts)
+  - ✅ Validate ports and modules (HTTP/HTTPS ports, module names)
+  - ✅ Validate main settings and environment variables
+  - ✅ Validate security settings structure
+  - ✅ Validate virtual hosts configuration
+  - ✅ Validate authentication configuration (htpasswd files and users)
+  - ✅ Include validation in main.yml with 'always' tag
+  - ✅ Test validation with molecule converge
+
+**Technical Debt:**
+- ✅ ~~PHP integration tests temporarily disabled in Apache molecule tests~~ - RESOLVED: Tests enabled in converge.yml
+- ✅ ~~Need to complete PHP role implementation before re-enabling integration tests~~ - RESOLVED: PHP role complete
+- ✅ ~~Configure PHP-FPM as default version when enabled~~ - RESOLVED: Implemented apache_php_fpm_set_default variable
+- ✅ ~~Real-time status endpoint returns 404 error~~ - RESOLVED: Fixed Directory directive and created HTML template
+- Integrate with CA provider like letsencrypt or get certs for another provider / source (i accept suggestions)
+- ✅ ~~Update role documentation (README.md) for php and apache~~ - RESOLVED: Comprehensive READMEs created
+- ✅ ~~Update collection documentation~~ - RESOLVED: Collection README updated with features, examples, and use cases
+
+# PHP Role Functional Requirements
+
+## 1. PHP Installation
+- **Repository Management:**
+  - ✅ Add third-party PHP repository for accessing specific PHP versions
+
+- **Package Installation:**
+  - ✅ Install PHP core and extensions from configurable package list
+  - ✅ Support PHP-FPM installation when enabled
+  - ✅ Support Composer installation when enabled
+  - ✅ Install packages idempotently
+  - ✅ Ensure FPM service is started and enabled
+## 2. PHP Configuration Management
+### 2.1 CLI Configuration
+- **Configuration File Management:**
+  - ✅ Backup original php.ini before modifications
+  - ✅ Update PHP settings using regex-based replacements
+  - ✅ Support comprehensive configuration options:
+    - ✅ Execution limits (max_execution_time, max_input_time, max_input_vars)
+    - ✅ Memory management (memory_limit)
+    - ✅ Error handling (error_reporting, display_errors, error_log)
+    - ✅ Upload limits (post_max_size, upload_max_filesize, max_file_uploads)
+    - ✅ Behavior settings (short_open_tag, mail headers)
+  - ✅ Create custom log directories
+
+### 2.2 FPM Configuration
+- **PHP-FPM Settings:**
+  - ✅ Backup original FPM php.ini before modifications
+  - ✅ Configure FPM-specific PHP settings independently from CLI
+  - ✅ Support same configuration options as CLI with different defaults
+  - ✅ Restart FPM service only when configuration changes
+
+- **FPM Pool Configuration:**
+  - ✅ Backup original pool configuration
+  - ✅ Configure FPM pool settings:
+    - ✅ Process manager type (static, dynamic, ondemand)
+    - ✅ Process limits (pm_max_children, pm_start_servers, pm_min_spare_servers, pm_max_spare_servers)
+  - ✅ Create pool configuration from templates
+
+### 2.3 PHP Version Management
+- **CLI Version Management:**
+  - ✅ Set default PHP CLI version using system alternatives
+  - ✅ Update php, phar, phar.phar, phpize, and php-config alternatives
+  - ✅ Create symlinks for default version tools
+
+### 2.4 Microsoft SQL Server Extension
+- **MSSQL Driver Installation:**
+  - ✅ Add Microsoft repository and GPG key
+  - ✅ Install Microsoft ODBC driver with EULA acceptance
+  - ✅ Install mssql-tools with command-line utilities
+  - ✅ Add mssql-tools to system PATH
+
+- **PHP MSSQL Extension Compilation:**
+  - ✅ Install sqlsrv and pdo_sqlsrv extensions using PECL
+  - ✅ Create module configuration files with correct priority
+  - ✅ Enable extensions using phpenmod
+  - ✅ Skip compilation if extensions already exist
+
+### 2.5 Log Rotation
+- **CLI Log Rotation:**
+  - ✅ Configure logrotate for PHP CLI error logs
+  - ✅ Support custom log paths
+  - ✅ Create logrotate configuration from templates
+
+- **FPM Log Rotation:**
+  - ✅ Configure logrotate for PHP-FPM logs
+  - ✅ Support custom FPM log paths
+  - ✅ Create version-specific logrotate configuration
+
+### ✅ 2.6 Uninstall php version
+- **Version Upgrade/Downgrade:**
+  - ✅ Remove old PHP versions when specified
+  - ✅ Stop and disable old PHP-FPM services
+  - ✅ Clean up old packages, configuration files, and logs
+  - ✅ Remove old extension files and directories
+  - ✅ Support clean migration between versions
+
+# General Functional Requirements
+
+## ✅ 1. Testing Requirements
+- **Molecule Tests:**
+  - ✅ Support create, converge, verify, and destroy lifecycle
+
+## ✅ 2. Integration Requirements
+- **Web Server Integration:**
+  - ✅ Integrate with web servers via environment variables
+  - ✅ Configure FPM status page endpoint access
+  - ✅ Add file existence checks for secure execution
+
+- **Tag Support:**
+  - ✅ Support role-wide tags (php_*)
+  - ✅ Support task-specific tags for granular execution
+  - ✅ Allow selective execution of specific functionality
+  - ✅ Support conditional task execution based on variables
+
+## ✅ 3. Idempotency Requirements
+- **Change Detection:**
+  - ✅ Check if files exist before creating backups
+  - ✅ Use 'creates' parameter for idempotent installations
+  - ✅ Register and check task results before triggering handlers
+  - ✅ Only restart/reload services when configuration actually changes
+  - Test in check mode and diff mode
+
+# ✅ Playbooks
+  - ✅ Create playbook for Setup an web_server (apache + php). Use the roles in te collection
+  - ✅ Create playbook for Setup an web_server with multiples php versions (apache + php). Use the roles in te collection
+  - Create scenarios for test multi php playbook
+
+
+- Improve github CI/CD tasks (cache, etc)


### PR DESCRIPTION
### Added
- Validation for virtual host `listen` ports to ensure they match configured `apache_http_ports` or `apache_https_ports`
- Default values for virtual host `listen` attribute (`*:80` for HTTP, `*:443` for HTTPS)

### Fixed
- Virtual host templates now use default listen values when not explicitly defined
- Fixed variable name typo: `apache_vhosts_from_templates` → `apache_vhosts_from_template`
- Fixed Apache handler to properly guard against accessing undefined attributes in check mode
- Add ## {mark} ANSIBLE MANAGED FILE ## to logrotate files in php role